### PR TITLE
Added global variable with the current datetime

### DIFF
--- a/lib/engines/nunjucks.js
+++ b/lib/engines/nunjucks.js
@@ -65,6 +65,9 @@ class NunjucksEngine extends BaseEngine {
     // add global reference to the current path prefix
     this.env.addGlobal('PATH_PREFIX', this.pathPrefix);
 
+    // add global reference to the current date and time
+    this.env.addGlobal('NOW', new Date());
+
     this.env.on('load', (_, { path }) => {
       this.addDependency(path);
     });


### PR DESCRIPTION
This will be useful downstream for all sorts of things, like printing the current year in the copyright in the footer. It's also a standard context variable in other frameworks, like Django.