### PR TITLE
Make the dev watch work for createPages templates

### DIFF
--- a/lib/engines/nunjucks.js
+++ b/lib/engines/nunjucks.js
@@ -4,6 +4,7 @@ import { join, parse, relative, resolve } from 'path';
 
 // packages
 import { createCodeFrame } from 'simple-code-frame';
+import chokidar from 'chokidar';
 import debug from 'debug';
 import nunjucks from 'nunjucks';
 import { Environment, FileSystemLoader, Template } from 'nunjucks';
@@ -398,5 +399,46 @@ export class NunjucksEngine extends BaseEngine {
         resolve(text);
       });
     });
+  }
+
+  async watch(fn) {
+    const toWatch = Array.from(this.dependencies);
+
+    this.watcher = chokidar.watch(toWatch, {
+      ignoreInitial: true,
+    });
+
+    const onChange = async (path) => {
+
+      // find the files to work with
+      const files = await this.findFiles();
+
+      try {
+        for (const file of files) {
+          if (file !== path)
+            continue;
+          logger('┌╼ rendering', relative(this.input, file));
+          await this.outputFile(file);
+        }
+        // if we have a dynamic generator, let's find them
+        if (this.createPages) {
+          const { collect, renders } = this.collectDynamicRenders();
+          await this.createPages(collect, this.context);
+
+          for (const [inputPath, outputPath, localContext] of renders) {
+            if (inputPath !== path)
+              continue;
+            logger('┌╼ dynamically rendering', outputPath);
+            await this.outputFile(inputPath, outputPath, localContext);
+          }
+        }
+      } catch (err) {
+        throw err;
+      }
+    };
+
+    this.watcher.on('add', onChange);
+    this.watcher.on('change', onChange);
+    this.watcher.on('unlink', onChange);
   }
 }


### PR DESCRIPTION
This fixes the nunjucks engine watch so that it will rebuild the create pages on watch trigger. Without this fix, the dev server explodes with a template error as all of the context variables are undefined upon watch fire.

With this, I don't have to restart the dev server every time I make a change to a template file. It rebuilds *every* templated/`createPage` file in the baker config when it notices a change anywhere. (So it's could be slow on a very large number of create pages.)

I've been testing this (and using it on a project for ~6 months) and it appears to work well. There are still some issues with changing assets inside of the `_data/` folder, but I'm not sure it's related to this or was an existing issue.