### PR TITLE
Update SASS import

### DIFF
--- a/lib/engines/sass.js
+++ b/lib/engines/sass.js
@@ -3,7 +3,7 @@ import { format, relative } from 'path';
 
 // packages
 import debug from 'debug';
-import sass from 'sass';
+import * as sass from 'sass';
 import CleanCSS from 'clean-css';
 import autoprefixer from 'autoprefixer';
 import postcss from 'postcss';


### PR DESCRIPTION
We are currently getting this warning at boot.

```
`import sass from 'sass'` is deprecated.
Please use `import * as sass from 'sass'` instead.
```