### PR TITLE
Fix: remove file path matching for dev nunjucks watcher

### DIFF
--- a/lib/engines/nunjucks.js
+++ b/lib/engines/nunjucks.js
@@ -415,8 +415,6 @@ export class NunjucksEngine extends BaseEngine {
 
       try {
         for (const file of files) {
-          if (file !== path)
-            continue;
           logger('┌╼ rendering', relative(this.input, file));
           await this.outputFile(file);
         }


### PR DESCRIPTION
When we make changes to the `_layouts` folder, the nunjucks watch function sees it but does not rebuild associated pages.

Issue example:
1. Make change to `_layouts/header.html`
2. Check localhost:3000
3. Nothing changes

We noticed it would work if we:
1. Make change to `_layouts/header.html`
2. Save `index.html`
3. Check localhost:3000
4. See changes

With help from @brandonrobertz, we tracked it down to the `lib/engines/nunjucks.js` file. 

We suspect that

```
    if (file !== path)
        continue;
```

was ignoring layouts changes because it would see that `_layouts/header.html != index.html` and ignore it. Removing this seemed to have fixed this issue. 